### PR TITLE
feat(simple-access): support rerun of promise or sync data from the can method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "simple-access",
-    "version": "1.0.2",
+    "version": "2.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "simple-access",
-            "version": "1.0.2",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.11.0",

--- a/src/adapters/baseAdapter.ts
+++ b/src/adapters/baseAdapter.ts
@@ -1,9 +1,20 @@
 import { Role } from "../types";
 
+/**
+ * Base Adapter Class
+ * @class
+ * @typeParam T - Type of getRolesByName return, can be Array<Role> | Promise<Array<Role>>
+ */
 export abstract class BaseAdapter<
-    RT extends Array<Role> | Promise<Array<Role>>
+    T extends Array<Role> | Promise<Array<Role>>
 > {
     protected constructor(public name: string) {}
 
-    abstract getRolesByName(names: Array<string>): RT;
+    /**
+     * @method getRolesByName
+     * @template T - Type of return defined on extending the class, can be Array<Role> | Promise<Array<Role>>
+     * @param {Array<string>} names - Roles names
+     * @returns {T}
+     */
+    abstract getRolesByName(names: Array<string>): T;
 }

--- a/src/adapters/baseAdapter.ts
+++ b/src/adapters/baseAdapter.ts
@@ -1,9 +1,9 @@
 import { Role } from "../types";
 
-export abstract class BaseAdapter {
+export abstract class BaseAdapter<
+    RT extends Array<Role> | Promise<Array<Role>>
+> {
     protected constructor(public name: string) {}
 
-    abstract getRolesByName(
-        names: Array<string>
-    ): Promise<Array<Role>> | Array<Role>;
+    abstract getRolesByName(names: Array<string>): RT;
 }

--- a/src/adapters/memoryAdapter.ts
+++ b/src/adapters/memoryAdapter.ts
@@ -32,7 +32,7 @@ export class MemoryAdapter extends BaseAdapter<Array<Role>> {
     }
 
     getRolesByName(names: Array<string>): Array<Role> {
-        const result = [];
+        const result: Array<Role> = [];
 
         if (names == null) {
             throw new ErrorEx(

--- a/src/adapters/memoryAdapter.ts
+++ b/src/adapters/memoryAdapter.ts
@@ -1,7 +1,7 @@
 import { BaseAdapter } from "./baseAdapter";
 import { Role, ErrorEx } from "../types";
 
-export class MemoryAdapter extends BaseAdapter {
+export class MemoryAdapter extends BaseAdapter<Array<Role>> {
     private _roles: Array<Role>;
     private _cache: { [k: string]: Role } = {};
 

--- a/src/simpleAccess.ts
+++ b/src/simpleAccess.ts
@@ -1,6 +1,13 @@
 import * as _ from "lodash";
 import Ajv from "ajv";
-import { Tuple, Role, ErrorEx, Action, CanReturnType } from "./types";
+import {
+    Tuple,
+    Role,
+    ErrorEx,
+    Action,
+    CanReturnType,
+    TypeOfClassMethodReturn,
+} from "./types";
 import { BaseAdapter } from "./adapters";
 import { Utils } from "./core";
 import { PermissionOptions, Permission } from "./types";
@@ -8,12 +15,13 @@ import { roleSchema } from "./validation";
 
 const ALL = "*";
 
-export class SimpleAccess {
-    constructor(
-        private readonly _adapter: BaseAdapter<
-            Array<Role> | Promise<Array<Role>>
-        >
-    ) {
+/**
+ * SimpleAccess Adapter Class
+ * @class
+ * @typeParam T - Type of Adapter
+ */
+export class SimpleAccess<T extends BaseAdapter<any>> {
+    constructor(private readonly _adapter: T) {
         if (this._adapter == null) {
             throw new ErrorEx(
                 ErrorEx.VALIDATION_ERROR,
@@ -193,7 +201,7 @@ export class SimpleAccess {
         return resources;
     }
 
-    get adapter(): BaseAdapter<Array<Role> | Promise<Array<Role>>> {
+    get adapter(): T {
         return this._adapter;
     }
 
@@ -264,6 +272,7 @@ export class SimpleAccess {
     /**
      * Check the ability of accessing a resource through one or more roles (assigned to subject)
      * and the ability of executing specific action on this resource
+     * @method
      * @param {Array<string> | string} role One or more roles
      * @param {Array<string> | string} action Action name (Like "create")
      * @param {string} resource Resource name (Like "order")
@@ -273,7 +282,7 @@ export class SimpleAccess {
         role: Array<string> | string,
         action: string,
         resource: string
-    ): CanReturnType<ReturnType<typeof this._adapter.getRolesByName>> {
+    ): CanReturnType<TypeOfClassMethodReturn<T, "getRolesByName">> {
         const roleNames = Array.isArray(role) ? role : [role];
 
         roleNames.forEach((r) => {
@@ -298,9 +307,7 @@ export class SimpleAccess {
         if (roles instanceof Promise) {
             return roles.then((rolesArray) => {
                 return this.getPermission(role, action, resource, rolesArray);
-            }) as CanReturnType<
-                ReturnType<typeof this._adapter.getRolesByName>
-            >;
+            }) as CanReturnType<TypeOfClassMethodReturn<T, "getRolesByName">>;
         }
 
         return this.getPermission(
@@ -308,7 +315,7 @@ export class SimpleAccess {
             action,
             resource,
             roles
-        ) as CanReturnType<ReturnType<typeof this._adapter.getRolesByName>>;
+        ) as CanReturnType<TypeOfClassMethodReturn<T, "getRolesByName">>;
     }
 
     /**

--- a/src/simpleAccess.ts
+++ b/src/simpleAccess.ts
@@ -51,6 +51,21 @@ export class SimpleAccess<T extends BaseAdapter<any>> {
     }
 
     /**
+     * Validate roles returned by the adapter
+     * @param {Array<Role>} roles Roles array
+     * @returns {void}
+     * @protected
+     */
+    protected validatedAdapterRoles(roles: Array<Role>): void {
+        if (roles == null) {
+            throw new ErrorEx(
+                ErrorEx.VALIDATION_ERROR,
+                `Invalid roles array, returned by adapter`
+            );
+        }
+    }
+
+    /**
      * Build hash table from one or more roles, merging resources and actions
      * @param {Array<Role>} roles Roles array
      * @returns {{[p: string]: Tuple}} Object with merged resources, including internal data like attributes
@@ -298,25 +313,15 @@ export class SimpleAccess<T extends BaseAdapter<any>> {
         const roles = this._adapter.getRolesByName(roleNames);
 
         if (roles instanceof Promise) {
-            return roles.then((rolesArray: Role[]) => {
+            return roles.then((rolesArray: Array<Role>) => {
                 // Validate that all roles are available in roles list
-                if (rolesArray == null) {
-                    throw new ErrorEx(
-                        ErrorEx.VALIDATION_ERROR,
-                        `Invalid roles array, returned by adapter`
-                    );
-                }
+                this.validatedAdapterRoles(rolesArray);
                 return this.getPermission(role, action, resource, rolesArray);
             }) as CanReturnType<TypeOfClassMethodReturn<T, "getRolesByName">>;
         }
 
         // Validate that all roles are available in roles list
-        if (roles == null) {
-            throw new ErrorEx(
-                ErrorEx.VALIDATION_ERROR,
-                `Invalid roles array, returned by adapter`
-            );
-        }
+        this.validatedAdapterRoles(roles);
 
         return this.getPermission(
             role,
@@ -332,7 +337,7 @@ export class SimpleAccess<T extends BaseAdapter<any>> {
      * @param {Tuple} data
      * @returns {any}
      */
-    filter(permission: Permission, data: Tuple) {
+    filter(permission: Permission, data: Tuple): any {
         return Utils.filter(permission, data);
     }
 }

--- a/src/simpleAccess.ts
+++ b/src/simpleAccess.ts
@@ -296,18 +296,26 @@ export class SimpleAccess<T extends BaseAdapter<any>> {
 
         // Get roles by their names
         const roles = this._adapter.getRolesByName(roleNames);
+
+        if (roles instanceof Promise) {
+            return roles.then((rolesArray: Role[]) => {
+                // Validate that all roles are available in roles list
+                if (rolesArray == null) {
+                    throw new ErrorEx(
+                        ErrorEx.VALIDATION_ERROR,
+                        `Invalid roles array, returned by adapter`
+                    );
+                }
+                return this.getPermission(role, action, resource, rolesArray);
+            }) as CanReturnType<TypeOfClassMethodReturn<T, "getRolesByName">>;
+        }
+
         // Validate that all roles are available in roles list
         if (roles == null) {
             throw new ErrorEx(
                 ErrorEx.VALIDATION_ERROR,
                 `Invalid roles array, returned by adapter`
             );
-        }
-
-        if (roles instanceof Promise) {
-            return roles.then((rolesArray) => {
-                return this.getPermission(role, action, resource, rolesArray);
-            }) as CanReturnType<TypeOfClassMethodReturn<T, "getRolesByName">>;
         }
 
         return this.getPermission(

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -41,3 +41,15 @@ export interface Action {
     attributes?: Array<string>;
     scope?: Tuple;
 }
+
+export type TypeOfClassMethod<T, M extends keyof T> = T[M] extends (
+    ...args: any
+) => any
+    ? T[M]
+    : never;
+
+export type TypeOfClassMethodReturn<T, M extends keyof T> = T[M] extends (
+    ...args: any
+) => any
+    ? ReturnType<T[M]>
+    : never;

--- a/src/types/permission.ts
+++ b/src/types/permission.ts
@@ -1,4 +1,4 @@
-import { Tuple } from "./common";
+import { Tuple, Role } from "./common";
 import { Access, IAccessInfo } from "./access";
 import { Utils } from "../core";
 
@@ -54,3 +54,6 @@ export class Permission {
         return Utils.filter(this, data);
     }
 }
+
+export type CanReturnType<T extends Array<Role> | Promise<Array<Role>>> =
+    T extends Array<Role> ? Permission : Promise<Permission>;

--- a/test/data/roles.ts
+++ b/test/data/roles.ts
@@ -1,5 +1,5 @@
 import { RESOURCES } from "./resources";
-import { Role } from "../../src";
+import { type Role } from "../../src";
 
 export const ROLES = {
     ADMINISTRATOR: "administrator",

--- a/test/simpleAccess/memoryAdapter.spec.ts
+++ b/test/simpleAccess/memoryAdapter.spec.ts
@@ -4,7 +4,7 @@ import { SimpleAccess, Role, MemoryAdapter, ErrorEx } from "../../src";
 import { Roles } from "../data";
 
 let adapter: MemoryAdapter;
-let acl: SimpleAccess;
+let acl: SimpleAccess<MemoryAdapter>;
 
 before(() => {
     adapter = new MemoryAdapter(Roles as Role[]);

--- a/test/simpleAccess/simpleAccess.spec.ts
+++ b/test/simpleAccess/simpleAccess.spec.ts
@@ -5,7 +5,7 @@ import { ErrorEx, Role, Permission } from "../../src";
 import { Roles, ROLES, RESOURCES, PRODUCTS } from "../data";
 import { SimpleAccess, BaseAdapter, MemoryAdapter } from "../../src";
 
-let adapter: BaseAdapter;
+let adapter: BaseAdapter<Array<Role>>;
 let acl: SimpleAccess;
 
 before(() => {

--- a/test/simpleAccess/simpleAccess.spec.ts
+++ b/test/simpleAccess/simpleAccess.spec.ts
@@ -3,10 +3,10 @@ import { before, describe, it } from "mocha";
 
 import { ErrorEx, Role, Permission } from "../../src";
 import { Roles, ROLES, RESOURCES, PRODUCTS } from "../data";
-import { SimpleAccess, BaseAdapter, MemoryAdapter } from "../../src";
+import { SimpleAccess, MemoryAdapter } from "../../src";
 
-let adapter: BaseAdapter<Array<Role>>;
-let acl: SimpleAccess;
+let adapter: MemoryAdapter;
+let acl: SimpleAccess<MemoryAdapter>;
 
 before(() => {
     adapter = new MemoryAdapter(Roles as any[]);
@@ -46,7 +46,7 @@ describe("Test core functionalities", () => {
         );
 
         try {
-            await simpleAccess.can([ROLES.SUPPORT], "ready", RESOURCES.PRODUCT);
+            simpleAccess.can([ROLES.SUPPORT], "ready", RESOURCES.PRODUCT);
         } catch (e) {
             expect(e)
                 .to.be.instanceOf(Error)
@@ -58,7 +58,7 @@ describe("Test core functionalities", () => {
     it("Should return validation error, for missing role", async () => {
         const ROLE_NAME = "finance";
         try {
-            await acl.can(ROLE_NAME, "create", "product");
+            acl.can(ROLE_NAME, "create", "product");
         } catch (e) {
             expect(e)
                 .to.be.instanceOf(Error)
@@ -74,7 +74,7 @@ describe("Test core functionalities", () => {
 
     it("Should return validation error object, if role is invalid", async () => {
         try {
-            await acl.can(undefined, "read", "product");
+            acl.can(undefined, "read", "product");
         } catch (e) {
             expect(e)
                 .to.be.instanceOf(Error)
@@ -85,7 +85,7 @@ describe("Test core functionalities", () => {
 
     it("Should return validation error object, if one or more roles are invalid", async () => {
         try {
-            await acl.can([ROLES.ADMINISTRATOR, undefined], "read", "product");
+            acl.can([ROLES.ADMINISTRATOR, undefined], "read", "product");
         } catch (e) {
             expect(e)
                 .to.be.instanceOf(Error)
@@ -96,7 +96,7 @@ describe("Test core functionalities", () => {
 
     it("Should return validation error object, if one or more roles are missing", async () => {
         try {
-            await acl.can([ROLES.ADMINISTRATOR, "auditor"], "read", "product");
+            acl.can([ROLES.ADMINISTRATOR, "auditor"], "read", "product");
         } catch (e) {
             expect(e)
                 .to.be.instanceOf(Error)
@@ -113,7 +113,7 @@ describe("Test permission object", () => {
     const RESOURCE_NAME = RESOURCES.ORDER;
 
     before(async () => {
-        permission = await acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
+        permission = acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
     });
 
     it("Should return permission object", async () => {
@@ -156,37 +156,25 @@ describe("Test permission object", () => {
 
 describe("Test can functionality with single role", () => {
     it("Should return permission with granted equal false when resource does not exist", async () => {
-        const permission = await acl.can(
-            [ROLES.OPERATION],
-            "delete",
-            "languages"
-        );
+        const permission = acl.can([ROLES.OPERATION], "delete", "languages");
         const { granted } = permission;
         expect(granted).to.be.equal(false);
     });
 
     it("Should return permission with granted equal false when action is not allowed", async () => {
-        const permission = await acl.can(
-            [ROLES.OPERATION],
-            "delete",
-            RESOURCES.FILE
-        );
+        const permission = acl.can([ROLES.OPERATION], "delete", RESOURCES.FILE);
         const { granted } = permission;
         expect(granted).to.be.equal(false);
     });
 
     it("Should return permission with granted equal true when action is allowed on resource", async () => {
-        const permission = await acl.can(
-            [ROLES.OPERATION],
-            "read",
-            RESOURCES.ORDER
-        );
+        const permission = acl.can([ROLES.OPERATION], "read", RESOURCES.ORDER);
         const { granted } = permission;
         expect(granted).to.be.equal(true);
     });
 
     it("Should return permission with granted equal true when subject has access to all actions on resource", async () => {
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR],
             "readAll",
             RESOURCES.FILE
@@ -203,7 +191,7 @@ describe("Test can functionality with overlapped roles - permission access", () 
     const RESOURCE_NAME = RESOURCES.PRODUCT;
 
     before(async () => {
-        permission = await acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
+        permission = acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
     });
 
     it("Should return permission object with granted equal true", async () => {
@@ -228,7 +216,7 @@ describe("Test can functionality with overlapped roles - resources", () => {
     const RESOURCE_NAME = RESOURCES.PRODUCT;
 
     before(async () => {
-        permission = await acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
+        permission = acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
     });
 
     it("Should return permission object with merged (union) resources", async () => {
@@ -250,7 +238,7 @@ describe("Test can functionality with overlapped roles - actions", () => {
     it("Should return permission object with merged (union) actions inside resource", async () => {
         const ROLE_NAME = [ROLES.ADMINISTRATOR, ROLES.OPERATION];
         const RESOURCE_NAME = RESOURCES.PRODUCT;
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             "read",
             RESOURCES.PRODUCT
@@ -280,7 +268,7 @@ describe("Test can functionality with overlapped roles - actions", () => {
     });
 
     it("Should return permission object with the most permissive action applied", async () => {
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             "read",
             RESOURCES.CONFIGURATION
@@ -295,7 +283,7 @@ describe("Test can functionality with overlapped roles - actions", () => {
     });
 
     it("Should return permission object with the most permissive action applied and granted access to custom action", async () => {
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             "print",
             RESOURCES.CONFIGURATION
@@ -315,7 +303,7 @@ describe("Test can functionality with overlapped roles - attributes", () => {
         const ACTION_NAME = "read";
         const RESOURCE_NAME = RESOURCES.PRODUCT;
         const RESULT = ["*", "!history"];
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             ACTION_NAME,
             RESOURCE_NAME
@@ -341,7 +329,7 @@ describe("Test can functionality with overlapped roles - attributes", () => {
     it("Should return permission object with all allowed attributes in action - filtered all attributes", async () => {
         const ACTION_NAME = "create";
         const RESOURCE_NAME = RESOURCES.PRODUCT;
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             ACTION_NAME,
             RESOURCE_NAME
@@ -368,7 +356,7 @@ describe("Test can functionality with overlapped roles - attributes", () => {
         const ACTION_NAME = "update";
         const RESOURCE_NAME = RESOURCES.ORDER;
         const RESULT = ["status", "items", "delivery"];
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.OPERATION, ROLES.SUPPORT],
             ACTION_NAME,
             RESOURCE_NAME
@@ -395,7 +383,7 @@ describe("Test can functionality with overlapped roles - attributes", () => {
         const ACTION_NAME = "read";
         const RESOURCE_NAME = RESOURCES.PRODUCT;
         const RESULT = ["*", "!history"];
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             ACTION_NAME,
             RESOURCE_NAME
@@ -422,7 +410,7 @@ describe("Test can functionality with overlapped roles - attributes", () => {
         const ACTION_NAME = "update";
         const RESOURCE_NAME = RESOURCES.PRODUCT;
         const RESULT = ["*", "!history"];
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             ACTION_NAME,
             RESOURCE_NAME
@@ -450,7 +438,7 @@ describe("Test can functionality with overlapped roles - scope", () => {
     it("Should return permission object with the most permissive scope applied", async () => {
         const ACTION_NAME = "read";
         const RESOURCE_NAME = RESOURCES.PRODUCT;
-        const permission = await acl.can(
+        const permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.OPERATION],
             ACTION_NAME,
             RESOURCE_NAME
@@ -477,7 +465,7 @@ describe("Test can functionality with overlapped roles - scope", () => {
         const ROLE_NAME = [ROLES.OPERATION, ROLES.SUPPORT];
         const ACTION_NAME = "read";
         const RESOURCE_NAME = RESOURCES.PRODUCT;
-        const permission = await acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
+        const permission = acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
 
         const {
             grants: { [RESOURCE_NAME]: resource },
@@ -522,7 +510,7 @@ describe("Test data filtration base on permission", () => {
     let permission: Permission;
 
     before(async () => {
-        permission = await acl.can([ROLES.SUPPORT], "read", RESOURCES.PRODUCT);
+        permission = acl.can([ROLES.SUPPORT], "read", RESOURCES.PRODUCT);
     });
 
     it("Should return true if user can read provided resource", async () => {
@@ -537,7 +525,7 @@ describe("Test permission bounded functionalities", () => {
     let permission: Permission;
 
     before(async () => {
-        permission = await acl.can(
+        permission = acl.can(
             [ROLES.ADMINISTRATOR, ROLES.SUPPORT],
             "read",
             RESOURCES.PRODUCT


### PR DESCRIPTION
- 🏷️ `baseAdapter.ts`: Added generic type `RT extends Array<Role> | Promise<Array<Role>` to define the `getRolesByName` method return type.
- 🏷️ `permission.ts`: Added new generic type `CanReturnType<T>`.
- ✨ `memoryAdapter.ts`: Defined the return type of the `getRolesByName` method.
- 🏷️ `simpleAccess.ts`: Added adapter type parameter.
- 🏷️ `simpleAccess.ts`: Updated the `can` method return type to be `CanReturnType<T>`.
- ✨ `simpleAccess.ts`: Added `getPermission` private method.
- ✅ Updated the unit test cases.
- 📝 Updated the documentation with the new modifications and use cases.