### PR TITLE
fix: prevent scope pollution when merging role grants

### DIFF
--- a/src/simpleAccess.ts
+++ b/src/simpleAccess.ts
@@ -111,7 +111,7 @@ export class SimpleAccess<
                         attributes: aObj.attributes
                             ? Array.from(aObj.attributes)
                             : [],
-                        scope: aObj.scope ? Object.assign(aObj.scope) : {},
+                        scope: aObj.scope ? Object.assign({}, aObj.scope) : {},
                     };
                     let cachedAction: Action<R[2]>;
 

--- a/test/simpleAccess/simpleAccess.spec.ts
+++ b/test/simpleAccess/simpleAccess.spec.ts
@@ -465,6 +465,42 @@ describe("Test can functionality with overlapped roles - scope", () => {
             .eql({});
     });
 
+
+    it("Should not mutate role scope definitions after merging overlapped roles", async () => {
+        const ROLE_NAME = [ROLES.OPERATION, ROLES.SUPPORT];
+        const ACTION_NAME = "read";
+        const RESOURCE_NAME = RESOURCES.PRODUCT;
+
+        const operationRoleBefore = acl
+            .adapter
+            .getRolesByName(ROLE_NAME)
+            .find((role) => role.name === ROLES.OPERATION) as any;
+        const operationResourceBefore = operationRoleBefore.resources.find(
+            (resource: any) => resource.name === RESOURCE_NAME
+        );
+        const operationActionBefore = operationResourceBefore.actions.find(
+            (action: any) =>
+                typeof action === "object" && action.name === ACTION_NAME
+        ) as any;
+
+        expect(operationActionBefore.scope).to.be.eql({ valid: true });
+
+        acl.can(ROLE_NAME, ACTION_NAME, RESOURCE_NAME);
+
+        const operationRoleAfter = acl
+            .adapter
+            .getRolesByName(ROLE_NAME)
+            .find((role) => role.name === ROLES.OPERATION) as any;
+        const operationResourceAfter = operationRoleAfter.resources.find(
+            (resource: any) => resource.name === RESOURCE_NAME
+        );
+        const operationActionAfter = operationResourceAfter.actions.find(
+            (action: any) =>
+                typeof action === "object" && action.name === ACTION_NAME
+        ) as any;
+
+        expect(operationActionAfter.scope).to.be.eql({ valid: true });
+    });
     it("Should return permission object with all scopes merged", async () => {
         const ROLE_NAME = [ROLES.OPERATION, ROLES.SUPPORT];
         const ACTION_NAME = "read";


### PR DESCRIPTION
### Motivation
- Prevent in-place mutation of adapter-backed role scope objects when merging multiple roles, which could permanently expand or alter stored scopes and leak permissions across requests.

### Description
- Clone each action `scope` when building internal resource grants by changing `Object.assign(aObj.scope)` to `Object.assign({}, aObj.scope)` in `src/simpleAccess.ts` so merges operate on a copy. 
- Add a regression test in `test/simpleAccess/simpleAccess.spec.ts` that asserts the OPERATION role’s `read` scope remains `{ valid: true }` before and after calling `can()` with overlapping roles.
- Modified files: `src/simpleAccess.ts` and `test/simpleAccess/simpleAccess.spec.ts`.

### Testing
- Ran the scoped tests with `npm test -- --grep "scope"` which passed (scope-related tests passing). 
- Ran the full test suite with `npm test` which passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af26cd8f1083248a075eb5983dbc0b)