### PR TITLE
fix: properly handle thenables and null async role results in can()

### DIFF
--- a/src/simpleAccess.ts
+++ b/src/simpleAccess.ts
@@ -60,7 +60,7 @@ export class SimpleAccess<
      * @protected
      */
     protected validatedAdapterRoles(roles: Array<Role<R>>): void {
-        if (roles == null) {
+        if (roles == null || !Array.isArray(roles)) {
             throw new ErrorEx(
                 ErrorEx.VALIDATION_ERROR,
                 `Invalid roles array, returned by adapter`
@@ -317,8 +317,14 @@ export class SimpleAccess<
         // Get roles by their names
         const roles = this._adapter.getRolesByName(roleNames);
 
-        if (roles instanceof Promise) {
-            return roles.then((rolesArray: Array<Role<R>>) => {
+        const isThenable =
+            roles != null &&
+            (typeof roles === "object" || typeof roles === "function") &&
+            "then" in roles &&
+            typeof roles.then === "function";
+
+        if (isThenable) {
+            return Promise.resolve(roles).then((rolesArray: Array<Role<R>>) => {
                 // Validate that all roles are available in roles list
                 this.validatedAdapterRoles(rolesArray);
                 return this.getPermission(role, action, resource, rolesArray);

--- a/test/simpleAccess/simpleAccess.spec.ts
+++ b/test/simpleAccess/simpleAccess.spec.ts
@@ -107,6 +107,48 @@ describe("Test core functionalities", () => {
     });
 });
 
+describe("Test can functionality with async adapters", () => {
+    it("Should handle thenable adapter results", async () => {
+        class ThenableAdapter extends MemoryAdapter<RoleDefinition> {
+            getRolesByName(names: Array<RoleDefinition[0]>): any {
+                const roles = super.getRolesByName(names);
+                return {
+                    then: (resolve: (value: Array<any>) => void) =>
+                        resolve(roles),
+                };
+            }
+        }
+
+        const simpleAccess = new SimpleAccess(new ThenableAdapter(Roles));
+        const permission = (await simpleAccess.can(
+            ROLES.SUPPORT,
+            "read",
+            RESOURCES.PRODUCT
+        )) as Permission;
+
+        expect(permission).to.be.instanceOf(Permission);
+        expect(permission.granted).to.be.equal(true);
+    });
+
+    it("Should return validation error when async adapter resolves to null", async () => {
+        class NullPromiseAdapter extends MemoryAdapter<RoleDefinition> {
+            getRolesByName(_: Array<RoleDefinition[0]>): any {
+                return Promise.resolve(null);
+            }
+        }
+
+        const simpleAccess = new SimpleAccess(new NullPromiseAdapter(Roles));
+
+        try {
+            await simpleAccess.can(ROLES.SUPPORT, "read", RESOURCES.PRODUCT);
+        } catch (e) {
+            expect(e)
+                .to.be.instanceOf(Error)
+                .with.property("name")
+                .to.be.equal(ErrorEx.VALIDATION_ERROR);
+        }
+    });
+});
 describe("Test permission object", () => {
     let permission: Permission = undefined;
     const ROLE_NAME = ROLES.SUPPORT;


### PR DESCRIPTION
### Motivation
- The `can()` method treated only native `Promise` instances as async and forwarded resolved values without robust validation, which caused TypeErrors when adapters returned non-native thenables or when promises resolved to `null`.
- The goal is to avoid availability crashes by normalizing thenables and validating adapter results before accessing array properties.

### Description
- Replace `instanceof Promise` check with a generic thenable detection and normalize using `Promise.resolve(...)` so non-native promises are handled correctly (`src/simpleAccess.ts`).
- Harden `validatedAdapterRoles` to reject non-array payloads in addition to `null` by checking `Array.isArray(roles)` (`src/simpleAccess.ts`).
- Add regression tests that cover a non-native thenable adapter and an async adapter resolving to `null` to ensure correct behavior and controlled validation errors (`test/simpleAccess/simpleAccess.spec.ts`).
- Changes are limited to `src/simpleAccess.ts` (behavior + validation) and `test/simpleAccess/simpleAccess.spec.ts` (new tests).

### Testing
- Ran the full test suite with `npm test`, and all tests passed: `41 passing`.
- The new regression tests validate thenable handling and null-resolution validation and both succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af267cea688324b8fae173d510afb5)