### PR TITLE
fix: prevent prototype pollution in access grants resolution

### DIFF
--- a/src/simpleAccess.ts
+++ b/src/simpleAccess.ts
@@ -14,6 +14,8 @@ import { PermissionOptions, Permission } from "./types";
 import { roleSchema } from "./validation";
 
 const ALL = "*";
+const hasOwn = (obj: object, key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(obj, key);
 
 /**
  * SimpleAccess Adapter Class
@@ -77,7 +79,7 @@ export class SimpleAccess<
     private getResources(roles: Array<Role<R>>): {
         [k: string]: any;
     } {
-        const resources: { [k: string]: any } = {};
+        const resources: { [k: string]: any } = Object.create(null);
         if (roles == null || roles.length === 0) {
             return resources;
         }
@@ -87,7 +89,8 @@ export class SimpleAccess<
                 let cachedResource = resources[resource.name];
                 // If resource does not exist, add to object
                 if (cachedResource == null) {
-                    cachedResource = resources[resource.name] = {};
+                    cachedResource = resources[resource.name] =
+                        Object.create(null);
                 }
 
                 // If resource has wildcard action then skip merging actions
@@ -271,13 +274,13 @@ export class SimpleAccess<
         pInfo.grants = resources;
 
         // Validate resource & ability, then update permission
-        if (resources[resource] != null) {
+        if (hasOwn(resources, resource)) {
             if (resources[resource] === ALL) {
                 // If subject has access to all actions within the resource
                 pInfo.attributes = [ALL];
                 pInfo.scope = {};
                 pInfo.granted = true;
-            } else if (resources[resource][action] != null) {
+            } else if (hasOwn(resources[resource], action)) {
                 // If subject has access specific actions within the resource
                 const { attributes, scope } = resources[resource][action];
                 pInfo.attributes = attributes || [];

--- a/test/simpleAccess/simpleAccess.spec.ts
+++ b/test/simpleAccess/simpleAccess.spec.ts
@@ -155,6 +155,33 @@ describe("Test permission object", () => {
     });
 });
 
+describe("Security regression", () => {
+    it("Should not grant permission via inherited prototype properties", async () => {
+        const pollutedRoles: any = [
+            {
+                name: "attacker",
+                resources: [
+                    {
+                        name: "__proto__",
+                        actions: [
+                            {
+                                name: "read",
+                                attributes: ["*"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ];
+
+        const poisonedAcl = new SimpleAccess(new MemoryAdapter(pollutedRoles));
+        const permission = poisonedAcl.can("attacker", "read", "toString");
+
+        expect(permission.granted).to.be.equal(false);
+        expect(Object.keys(permission.grants)).to.be.eql(["__proto__"]);
+    });
+});
+
 describe("Test can functionality with single role", () => {
     it("Should return permission with granted equal false when resource does not exist", async () => {
         // @ts-ignore: Unreachable code error


### PR DESCRIPTION
### Motivation

- Prevent prototype pollution that allowed crafted role/resource names like `__proto__` to influence permission resolution and bypass authorization.
- The issue stems from using plain objects for merged grants and checking properties via normal property access which can return inherited prototype entries.

### Description

- Hardened grants maps in `src/simpleAccess.ts` by creating null-prototype objects with `Object.create(null)` for the top-level `resources` map and per-resource action maps to avoid prototype keys being interpreted as inherited properties.
- Added a safe own-property check helper `hasOwn` (`Object.prototype.hasOwnProperty.call`) and used it when resolving permissions so only own properties are considered when deciding grant status.
- Added a regression test in `test/simpleAccess/simpleAccess.spec.ts` that constructs a role with resource name `__proto__` and verifies it cannot grant access via inherited prototype properties.
- Preserved existing merge and aggregation logic while restricting checks to own properties and null-prototype maps so functionality remains unchanged for valid keys.

### Testing

- Ran the full test suite with `npm test -- --runInBand`, and all tests passed (`40 passing`).
- The new regression test ensures prototype-keyed resources no longer enable inherited permission checks and it passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af29d2b0d48324bae478636d6d7bba)